### PR TITLE
Make `PartialDeep` affect `ReturnType` of functions.

### DIFF
--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -10,8 +10,7 @@ export type PartialDeepOptions = {
 	@default false
 	*/
 	readonly recurseIntoArrays?: boolean;
-	
-	  
+
 	/**
 	Whether to affect the return type of functions.
 

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -12,7 +12,7 @@ export type PartialDeepOptions = {
 	readonly recurseIntoArrays?: boolean;
 	
 	  
-  	/**
+	/**
 	Whether to affect the return type of functions.
 
 	@default false

--- a/source/partial-deep.d.ts
+++ b/source/partial-deep.d.ts
@@ -10,6 +10,14 @@ export type PartialDeepOptions = {
 	@default false
 	*/
 	readonly recurseIntoArrays?: boolean;
+	
+	  
+  	/**
+	Whether to affect the return type of functions.
+
+	@default false
+	*/
+	readonly recurseIntoFunctions?: boolean;
 };
 
 /**
@@ -70,7 +78,10 @@ export type PartialDeep<T, Options extends PartialDeepOptions = {}> = T extends 
 				: T extends ReadonlySet<infer ItemType>
 					? PartialReadonlySetDeep<ItemType, Options>
 					: T extends ((...arguments: any[]) => unknown)
-						? T | undefined
+						? (Options['recurseIntoFunctions'] extends true
+							? (...arguments: Parameters<T>) => PartialDeep<ReturnType<T>, Options>
+							: T
+						) | undefined
 						: T extends object
 							? T extends ReadonlyArray<infer ItemType> // Test for arrays/tuples, per https://github.com/microsoft/TypeScript/issues/35156
 								? Options['recurseIntoArrays'] extends true


### PR DESCRIPTION
Add option in `PartialDeepOptions`: `recurseIntoFunctions`
Make `PartialDeep` affect `ReturnType` of functions.

E.g:
![image](https://user-images.githubusercontent.com/47786892/204195019-9685e19f-c3d1-4d9f-b552-0d3a4024aad4.png)
